### PR TITLE
pytest-asyncio 0.26.0 (patch to avoid setuptools 77)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@
 
 # Rattler-build's artifacts are in `output` when not specifying anything.
 /output
+# Pixi's configuration
+.pixi

--- a/recipe/0000-no-setuptools-77.patch
+++ b/recipe/0000-no-setuptools-77.patch
@@ -1,0 +1,16 @@
+diff --git a/pyproject.toml b/pyproject.toml
+index b368b48..dd842cc 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -10,10 +10,7 @@ name = "pytest-asyncio"
+ description = "Pytest support for asyncio"
+ readme.content-type = "text/x-rst"
+ readme.file = "README.rst"
+-license = "Apache-2.0"
+-license-files = [
+-  "LICENSE",
+-]
++license = {text = "Apache-2.0"}
+ authors = [
+   { name = "Tin Tvrtković <tinchester@gmail.com>", email = "tinchester@gmail.com" },
+ ]

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -34,7 +34,7 @@ requirements:
   run:
     - pytest >=8.2,<9
     - python >=${{ python_min }}
-    - typing_extensions>=4.12
+    - typing_extensions >=4.12
 
 tests:
   - python:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -12,6 +12,8 @@ source:
   - url: https://pypi.org/packages/source/p/pytest-asyncio/pytest_asyncio-${{ version }}.tar.gz
     sha256: c4df2a697648241ff39e7f0e4a73050b03f123f760673956cf0d72a4990e312f
     target_directory: dist
+    patches:
+      - 0000-no-setuptools-77.patch
   - url: https://github.com/pytest-dev/pytest-asyncio/archive/refs/tags/v${{ version }}.tar.gz
     sha256: 7bcd830bed05bc7d10068c49a844b8062af84537b846d61310f3b939ab0d013f
     target_directory: src
@@ -37,7 +39,9 @@ requirements:
 tests:
   - python:
       pip_check: true
-      python_version: ${{ python_min }}.*
+      python_version:
+        - ${{ python_min }}.*
+        - 3.13.*
       imports: pytest_asyncio
   - files:
       recipe:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -2,7 +2,7 @@
 schema_version: 1
 
 context:
-  version: 0.25.3
+  version: 0.26.0
 
 package:
   name: pytest-asyncio
@@ -10,10 +10,10 @@ package:
 
 source:
   - url: https://pypi.org/packages/source/p/pytest-asyncio/pytest_asyncio-${{ version }}.tar.gz
-    sha256: fc1da2cf9f125ada7e710b4ddad05518d4cee187ae9412e9ac9271003497f07a
+    sha256: c4df2a697648241ff39e7f0e4a73050b03f123f760673956cf0d72a4990e312f
     target_directory: dist
   - url: https://github.com/pytest-dev/pytest-asyncio/archive/refs/tags/v${{ version }}.tar.gz
-    sha256: 6e804b2a165f28f2a552e73e8ae2efd01f766d58510766dd6dd03be54583cd75
+    sha256: c4df2a697648241ff39e7f0e4a73050b03f123f760673956cf0d72a4990e312f
     target_directory: src
 
 build:
@@ -32,6 +32,7 @@ requirements:
   run:
     - pytest >=8.2,<9
     - python >=${{ python_min }}
+    - typing_extensions>=4.12
 
 tests:
   - python:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,7 +13,7 @@ source:
     sha256: c4df2a697648241ff39e7f0e4a73050b03f123f760673956cf0d72a4990e312f
     target_directory: dist
   - url: https://github.com/pytest-dev/pytest-asyncio/archive/refs/tags/v${{ version }}.tar.gz
-    sha256: c4df2a697648241ff39e7f0e4a73050b03f123f760673956cf0d72a4990e312f
+    sha256: 7bcd830bed05bc7d10068c49a844b8062af84537b846d61310f3b939ab0d013f
     target_directory: src
 
 build:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.


References:
- patch added to deal with current `setuptools 75` situation